### PR TITLE
Remove unnecessary news in GolemMaterialM*lastic

### DIFF
--- a/include/materials/GolemMaterialMElastic.h
+++ b/include/materials/GolemMaterialMElastic.h
@@ -86,22 +86,22 @@ protected:
   const MaterialProperty<Real> & _porosity_old;
   // SetPropertiesM
   // SetStrainModel
-  std::vector<const VariableGradient *> * _grad_disp_old;
+  std::vector<const VariableGradient *> _grad_disp_old;
   const MaterialProperty<RankTwoTensor> * _mechanical_strain_old;
-  std::vector<RankTwoTensor> * _strain_increment;
-  std::vector<RankTwoTensor> * _total_strain_increment;
+  std::vector<RankTwoTensor> _strain_increment;
+  std::vector<RankTwoTensor> _total_strain_increment;
   const MaterialProperty<RankTwoTensor> * _stress_old;
   const Real * _current_elem_volume;
-  std::vector<RankTwoTensor> * _Fhat;
+  std::vector<RankTwoTensor> _Fhat;
   MaterialProperty<RankTwoTensor> * _deformation_gradient;
   const MaterialProperty<RankTwoTensor> * _deformation_gradient_old;
   MaterialProperty<RankTwoTensor> * _rotation_increment;
   // setElasticModuli
   bool _crack_closure_set;
-  Real * _K_i;
-  Real * _K_end;
-  Real * _G;
-  Real * _p_hat;
+  Real _K_i;
+  Real _K_end;
+  Real _G;
+  Real _p_hat;
   // SetBackgroundStress
   std::vector<Function *> _background_stress;
   // ============================ HM properties ================================

--- a/src/materials/GolemMaterialMInelastic.C
+++ b/src/materials/GolemMaterialMInelastic.C
@@ -88,7 +88,7 @@ GolemMaterialMInelastic::GolemStress()
 
   if (_num_models == 0)
   {
-    _stress[_qp] = (*_stress_old)[_qp] + _Cijkl[_qp] * (*_strain_increment)[_qp];
+    _stress[_qp] = (*_stress_old)[_qp] + _Cijkl[_qp] * _strain_increment[_qp];
     _M_jacobian[_qp] = _Cijkl[_qp];
   }
   else if (_num_models == 1)
@@ -140,7 +140,7 @@ GolemMaterialMInelastic::updateQpStress(RankTwoTensor & combined_inelastic_strai
     {
       _models[i_mod]->setQp(_qp);
 
-      elastic_strain_increment = (*_strain_increment)[_qp];
+      elastic_strain_increment = _strain_increment[_qp];
 
       for (unsigned j_mod = 0; j_mod < _num_models; ++j_mod)
         if (i_mod != j_mod)
@@ -193,7 +193,7 @@ void
 GolemMaterialMInelastic::updateQpStressSingleModel(
     RankTwoTensor & combined_inelastic_strain_increment)
 {
-  RankTwoTensor elastic_strain_increment = (*_strain_increment)[_qp];
+  RankTwoTensor elastic_strain_increment = _strain_increment[_qp];
   _models[0]->setQp(_qp);
 
   _stress[_qp] = (*_stress_old)[_qp] + _Cijkl[_qp] * elastic_strain_increment;


### PR DESCRIPTION
There are two other news without deletes in `GolemFunctionBCFromFile`. In modern C++ there really should be no need for use of `new/delete`. It's just not safe. I encourage you to either use smart pointers, or in many cases avoid the need for use of pointers at all.

Sorry to sound irritated...but with a user coming for help from us (mauro) it's much easier to debug situations for which your code is valgrind clean.